### PR TITLE
Code fold fix, multiple selections, git commit

### DIFF
--- a/keybindings/keybindings.json
+++ b/keybindings/keybindings.json
@@ -114,5 +114,9 @@
     "key": "cmd+]",
     "command": "workbench.action.navigateForward",
     "when": "editorTextFocus"
+  },
+  { 
+    "key": "ctrl+v",          
+    "command": "workbench.view.git" 
   }
 ]

--- a/keybindings/keybindings.json
+++ b/keybindings/keybindings.json
@@ -38,8 +38,13 @@
   },
   {
     "key": "cmd+-",
-    "command": "editor.action.commentLine",
-    "when": "editorTextFocus"
+    "command": "editor.fold",
+    "when": "editorFocus"
+  },
+  {
+    "key": "cmd+=",
+    "command": "editor.unfold",
+    "when": "editorFocus"
   },
   {
     "key": "cmd+y",
@@ -85,6 +90,10 @@
   {
     "key": "shift+cmd+r",
     "command": "workbench.action.replaceInFiles"
+  },
+  {
+    "key": "ctrl+g",
+    "command": "editor.action.addSelectionToNextFindMatch"
   },
   {
     "key": "shift+cmd+]",


### PR DESCRIPTION
Fixes `cmd+-` - this folds code in IntelliJ, not comments, adds `cmd+=` which unfolds code

Adds `ctrl+g` - add next selection, like in IntelliJ

`ctrl+v` is git commit
