### PR TITLE
Updated move line down/up to match Intellij

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # intellij-visual-studio-code
-My (IntelliJ) key bindings for MS Visual Studio Code. I haven't used any of JetBrains other IDE:s but I'm guessing the bindings are the same for PhpStorm, PyCharm, RubyMine etc.
+My (IntelliJ Mac OS X 10.5+) key bindings for MS Visual Studio Code. I haven't used any of JetBrains other IDE:s but I'm guessing the bindings are the same for PhpStorm, PyCharm, RubyMine etc.
 
 # Usage
 1. Open user keybindings file.

--- a/keybindings/keybindings.json
+++ b/keybindings/keybindings.json
@@ -10,12 +10,12 @@ Key bindings that are more inline with IntelliJ
     "when": "editorTextFocus"
   },
   {
-    "key": "shift+cmd+down",
+    "key": "shift+alt+down",
     "command": "editor.action.moveLinesDownAction",
     "when": "editorTextFocus"
   },
   {
-    "key": "shift+cmd+up",
+    "key": "shift+alt+up",
     "command": "editor.action.moveLinesUpAction",
     "when": "editorTextFocus"
   },

--- a/keybindings/keybindings.json
+++ b/keybindings/keybindings.json
@@ -1,4 +1,4 @@
-Key bindings that are more inline with IntelliJ
+// Key bindings that are more inline with IntelliJ
 [
   {
     "key": "cmd+'",


### PR DESCRIPTION
The previous shortcut (shift+cmd+down/up) is used to move an entire code block in Intellij